### PR TITLE
add worker-plugin

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -13,6 +13,7 @@ const getCSSModuleLocalIdent = require("react-dev-utils/getCSSModuleLocalIdent")
 const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin");
 const postcssNormalize = require("postcss-normalize");
 const safePostCssParser = require("postcss-safe-parser");
+const WorkerPlugin = require('worker-plugin');
 
 const getClientEnvironment = require("./env");
 const paths = require("./paths");
@@ -388,6 +389,7 @@ module.exports = webpackEnv => {
       ]
     },
     plugins: [
+      new WorkerPlugin(),
       // Generates an `index.html` file with the <script> injected.
       new HtmlWebpackPlugin(
         Object.assign(

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -389,7 +389,7 @@ module.exports = webpackEnv => {
       ]
     },
     plugins: [
-      new WorkerPlugin(),
+      new WorkerPlugin({sharedWorker: true}),
       // Generates an `index.html` file with the <script> injected.
       new HtmlWebpackPlugin(
         Object.assign(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "solid-scripts",
-  "version": "0.0.31",
+  "version": "0.0.35",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -415,14 +415,6 @@
       "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
-      }
-    },
-    "@babel/plugin-syntax-jsx": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.8.3.tgz",
-      "integrity": "sha512-WxdW9xyLgBdefoo0Ynn3MRSkhe5tFVxxKNVdnZSh318WrG2e2jH+E9wd/++JsqcLJZPfz87njQJ8j2Upjm0M0A==",
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
     "@babel/plugin-syntax-logical-assignment-operators": {
@@ -2987,15 +2979,6 @@
         "@types/babel__traverse": "^7.0.6"
       }
     },
-    "babel-plugin-jsx-dom-expressions": {
-      "version": "0.17.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jsx-dom-expressions/-/babel-plugin-jsx-dom-expressions-0.17.3.tgz",
-      "integrity": "sha512-cWZNM14QJm8ke8HejEv5KvW/cGNmihSJdW+/51KIRtg1pqI6k0u+8ftTVgucTjLyzqB7lzwvFEpjqROnBAIMDA==",
-      "requires": {
-        "@babel/helper-module-imports": "^7.8.3",
-        "@babel/plugin-syntax-jsx": "^7.8.3"
-      }
-    },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
@@ -3034,14 +3017,6 @@
       "requires": {
         "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
         "babel-plugin-jest-hoist": "^24.9.0"
-      }
-    },
-    "babel-preset-solid": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-solid/-/babel-preset-solid-0.17.0.tgz",
-      "integrity": "sha512-Q1h14CD3Hv46tnxFljXZ3k6ayQfTTiHHW+rPCHW1tvOJQ/fp4QUOw8RQH04QguZwOEfTnviV0GTzZ5SIdk3AKw==",
-      "requires": {
-        "babel-plugin-jsx-dom-expressions": "~0.17.0"
       }
     },
     "babel-runtime": {
@@ -15846,6 +15821,14 @@
       "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
       "requires": {
         "errno": "~0.1.7"
+      }
+    },
+    "worker-plugin": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/worker-plugin/-/worker-plugin-4.0.3.tgz",
+      "integrity": "sha512-7hFDYWiKcE3yHZvemsoM9lZis/PzurHAEX1ej8PLCu818Rt6QqUAiDdxHPCKZctzmhqzPpcFSgvMCiPbtooqAg==",
+      "requires": {
+        "loader-utils": "^1.1.0"
       }
     },
     "worker-rpc": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "webpack": "^4.42.1",
     "webpack-dev-server": "^3.3.1",
     "webpack-manifest-plugin": "^2.0.4",
-    "workbox-webpack-plugin": "^4.3.0"
+    "workbox-webpack-plugin": "^4.3.0",
+    "worker-plugin": "^4.0.3"
   },
   "resolutions": {
     "webpack/acorn": "6.1.1"


### PR DESCRIPTION
https://github.com/GoogleChromeLabs/worker-plugin

https://github.com/ryansolid/solid-scripts/blob/master/templates/app/src/serviceWorker.js#L35
As is, `service-worker.js` cannot reference other modules installed via `npm`. With this plugin, I believe it's possible.

Also for my own personal use case, I'd like to use a sharedworker, but that doesn't have access to `localstorage`, so I need to use `kv-storage-polyfill`, but then if webpack doesn't bundle it, I can't use  the polyfill.